### PR TITLE
Add approle support

### DIFF
--- a/cmd/destination.go
+++ b/cmd/destination.go
@@ -217,6 +217,10 @@ var destinationCmd = &cobra.Command{
 		if viper.GetBool("origin.renewToken") {
 			go originVault.TokenRenewer(ctx, errCh)
 		}
+		// destination token renewer go routine
+		if viper.GetBool("destination.renewToken") {
+			go destinationVault.TokenRenewer(ctx, errCh)
+		}
 
 		// lock the main go routine in for select until we get os signals
 		for {

--- a/cmd/origin.go
+++ b/cmd/origin.go
@@ -144,6 +144,11 @@ var originCmd = &cobra.Command{
 			hasher, numBuckets, numWorkers,
 			errCh)
 
+		// origin token renewer go routine
+		if viper.GetBool("origin.renewToken") {
+			go originVault.TokenRenewer(ctx, errCh)
+		}
+
 		// lock the main go routine in for select until we get os signals
 		for {
 			select {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,11 +70,15 @@ func init() {
 	rootCmd.PersistentFlags().String("origin.consul.address", "", "origin consul address")
 	rootCmd.PersistentFlags().String("origin.vault.address", "", "origin vault address")
 	rootCmd.PersistentFlags().String("origin.vault.token", "", "origin vault token")
+	rootCmd.PersistentFlags().String("origin.vault.role_id", "", "origin vault approle role_id")
+	rootCmd.PersistentFlags().String("origin.vault.secret_id", "", "origin vault approle secret_id")
 
 	rootCmd.PersistentFlags().String("destination.dc", "", "destination datacenter")
 	rootCmd.PersistentFlags().String("destination.consul.address", "", "destination vault address")
 	rootCmd.PersistentFlags().String("destination.vault.address", "", "destination vault address")
 	rootCmd.PersistentFlags().String("destination.vault.token", "", "destination vault token")
+	rootCmd.PersistentFlags().String("destination.vault.role_id", "", "destination vault approle role_id")
+	rootCmd.PersistentFlags().String("destination.vault.secret_id", "", "destination vault approle secret_id")
 
 	if err := viper.BindPFlags(rootCmd.PersistentFlags()); err != nil {
 		log.Panic().Err(err).Str("command", "root").Str("flags", "persistent").Msg("cannot bind flags with viper")

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -100,6 +100,7 @@ func getEssentials(mode string) (*consul.Client, *vault.Client, error) {
 		log.Debug().Err(err).Str("mode", mode).Msg("cannot get vault client")
 		return c, nil, apperr.New(fmt.Sprintf("cannot get %s vault client", mode), err, op, apperr.Fatal, ErrInitialize)
 	}
+	v.Mode = mode
 
 	return c, v, nil
 }

--- a/configs/dest.v3.json
+++ b/configs/dest.v3.json
@@ -9,18 +9,21 @@
   "origin": {
     "dc": "dc1",
     "vault": {
-      "address": "http://127.0.0.1:6200",
-      "role_id": "4a79fd12-a1cd-430c-b991-5b9fcaf87887",
-      "secret_id": "eb27500d-f82b-49bc-8961-eb7ec5d8b305"
+      "address": "http://127.0.0.1:8200",
+      "approle": {
+        "path": "approle",
+        "role_id": "1a871568-7728-7ec2-3848-6e4250659198",
+        "secret_id": "bca693d3-1a7a-0fd1-10f9-9c61e10d207c"
+      }
     },
     "consul": {
-      "address": "http://127.0.0.1:6500"
+      "address": "http://127.0.0.1:8500"
     },
     "mounts": ["secret/"],
     "numWorkers": 5,
     "tick": "10s",
     "timeout": "10s",
-    "renewToken": false
+    "renewToken": true
   },
   "destination": {
     "dc": "dc2",

--- a/configs/dest.v3.json
+++ b/configs/dest.v3.json
@@ -1,0 +1,39 @@
+{
+  "name": "dest_v3",
+  "syncPath": "vsync/",
+  "log": {
+    "level": "debug",
+    "type": "console"
+  },
+  "numBuckets": 19,
+  "origin": {
+    "dc": "dc1",
+    "vault": {
+      "address": "http://127.0.0.1:6200",
+      "role_id": "4a79fd12-a1cd-430c-b991-5b9fcaf87887",
+      "secret_id": "eb27500d-f82b-49bc-8961-eb7ec5d8b305"
+    },
+    "consul": {
+      "address": "http://127.0.0.1:6500"
+    },
+    "mounts": ["secret/"],
+    "numWorkers": 5,
+    "tick": "10s",
+    "timeout": "10s",
+    "renewToken": false
+  },
+  "destination": {
+    "dc": "dc2",
+    "vault": {
+      "address": "http://127.0.0.1:7200",
+      "token": "s.5LvYTJQhwyh2CvrZtUpnHeLb"
+    },
+    "consul": {
+      "address": "http://127.0.0.1:7500"
+    },
+    "mounts": ["secret/"],
+    "numWorkers": 10,
+    "tick": "10s",
+    "timeout": "10s"
+  }
+}

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -73,7 +73,7 @@ func NewClient(address string, token string, roleID string, secretID string) (*C
 	if roleID != "" && secretID != "" {
 		token, err = GetAppRoleToken(address, roleID, secretID)
 		if err != nil {
-			fmt.Printf("%v", err)
+			return nil, apperr.New(fmt.Sprintf("cannot get correct a token from role_id: %q and secret_id: %q, %v", roleID, secretID, err), err, op, apperr.Fatal, ErrInitialize)
 		}
 	}
 

--- a/website/docs/getstarted/config.md
+++ b/website/docs/getstarted/config.md
@@ -22,6 +22,7 @@ sidebar_label: Config
 `syncPath` : consul kv path where vsync has to store its meta data (default: "vsync/")
 
 `dataPaths` : array of vault paths / mounts which needs to be synced
+
 > Deprecated after v0.0.1, replaced by mounts in origin and destination
 
 `log.level` : level of logs that needs to be printed to output; options: info | debug (default: "info")
@@ -41,6 +42,10 @@ sidebar_label: Config
 `origin.vault.address` : origin vault address where we need to get metadata ( vault kv metadata ). "--origin.vault.address" cli param
 
 `origin.vault.token` : origin vault token which has permissions to read, update, write in vault mounts. "--origin.vault.token" cli param
+
+`origin.vault.role_id` : origin vault role_id from an approle which has permissions to read, update, write in vault mounts. "--origin.vault.role_id" cli param (use token OR approle)
+
+`origin.vault.secret_id` : origin vault secret_id from an approle which has permissions to read, update, write in vault mounts. "--origin.vault.secret_id" cli param (use token OR approle)
 
 `origin.mounts` : array of vault paths / mounts which needs to be synced. Each value needs to end with /. Token permissions to read, update, delete are checked for each cycle.
 
@@ -66,6 +71,10 @@ sidebar_label: Config
 
 `destination.vault.token` : destination vault token which has permissions to read, update, write in vault mounts. "--destination.vault.token" cli param
 
+`destination.vault.role_id` : destination vault role_id from an approle which has permissions to read, update, write in vault mounts. "--destination.vault.role_id" cli param (use token OR approle)
+
+`destination.vault.secret_id` : destination vault secret_id from an approle which has permissions to read, update, write in vault mounts. "--destination.vault.secret_id" cli param (use token OR approle)
+
 `destination.mounts` : array of vault paths / mounts which needs to be synced. Each value needs to end with /. Token permissions to read, update, delete are checked for each cycle.
 
 `destination.consul.address` : destination consul address where we need to store vsync meta data ( sync info ). "--destination.consul.address" cli param
@@ -87,6 +96,7 @@ Supported format: json, hcl, yaml through [viper](https://github.com/spf13/viper
 ## Examples
 
 ### Origin
+
 ```
 {
     "syncPath": "vsync/",

--- a/website/docs/getstarted/config.md
+++ b/website/docs/getstarted/config.md
@@ -43,9 +43,11 @@ sidebar_label: Config
 
 `origin.vault.token` : origin vault token which has permissions to read, update, write in vault mounts. "--origin.vault.token" cli param
 
-`origin.vault.role_id` : origin vault role_id from an approle which has permissions to read, update, write in vault mounts. "--origin.vault.role_id" cli param (use token OR approle)
+`origin.vault.approle.path` : origin vault approle path. "--origin.vault.approle.path" cli param (use token OR approle) (default: approle)
 
-`origin.vault.secret_id` : origin vault secret_id from an approle which has permissions to read, update, write in vault mounts. "--origin.vault.secret_id" cli param (use token OR approle)
+`origin.vault.approle.role_id` : origin vault role_id from an approle which has permissions to read, update, write in vault mounts. "--origin.vault.approle.role_id" cli param (use token OR approle)
+
+`origin.vault.approle.secret_id` : origin vault secret_id from an approle which has permissions to read, update, write in vault mounts. "--origin.vault.approle.secret_id" cli param (use token OR approle)
 
 `origin.mounts` : array of vault paths / mounts which needs to be synced. Each value needs to end with /. Token permissions to read, update, delete are checked for each cycle.
 
@@ -71,9 +73,11 @@ sidebar_label: Config
 
 `destination.vault.token` : destination vault token which has permissions to read, update, write in vault mounts. "--destination.vault.token" cli param
 
-`destination.vault.role_id` : destination vault role_id from an approle which has permissions to read, update, write in vault mounts. "--destination.vault.role_id" cli param (use token OR approle)
+`destination.vault.approle.path` : destination vault approle path. "--destination.vault.approle.path" cli param (use token OR approle) (default: approle)
 
-`destination.vault.secret_id` : destination vault secret_id from an approle which has permissions to read, update, write in vault mounts. "--destination.vault.secret_id" cli param (use token OR approle)
+`destination.vault.approle.role_id` : destination vault role_id from an approle which has permissions to read, update, write in vault mounts. "--destination.vault.approle.role_id" cli param (use token OR approle)
+
+`destination.vault.approle.secret_id` : destination vault secret_id from an approle which has permissions to read, update, write in vault mounts. "--destination.vault.approle.secret_id" cli param (use token OR approle)
 
 `destination.mounts` : array of vault paths / mounts which needs to be synced. Each value needs to end with /. Token permissions to read, update, delete are checked for each cycle.
 


### PR DESCRIPTION
Hi,

This add the possibility to use an approle as login, and so a policy with less privileges.
https://www.vaultproject.io/docs/auth/approle

I added a `dest_v3.json` example.
And here an example of vault policy for the origin.

```
path "auth/token/lookup-self" {
  capabilities = ["read"]
}
path "kv/*" {
  capabilities = ["list", "read"]
}
path "kv/data/vsyncChecks" {
  capabilities = ["list", "read", "create", "update", "delete"]
}
path "kv/data/vsyncChecks/*" {
  capabilities = ["list", "read", "create", "update", "delete"]
}
path "kv/metadata/vsyncChecks" {
  capabilities = ["list", "read", "create", "update", "delete"]
}
path "kv/metadata/vsyncChecks/*" {
  capabilities = ["list", "read", "create", "update", "delete"]
}
path "sys/mounts" {
  capabilities = ["list", "read"]
}
path "sys/mounts/*" {
  capabilities = ["list", "read"]
}
``` 

I would like next try to give some improvement in `check.go` and `origin.go` in another PR to be able to give no right permissions at all on the origin.

Regards,