### PR TITLE
Sync paths needs to be different for origin and destination

### DIFF
--- a/cmd/destination.go
+++ b/cmd/destination.go
@@ -54,7 +54,9 @@ func init() {
 			Msg("cannot bind flags with viper")
 	}
 
-	if err := viper.BindPFlags(destinationCmd.Flags()); err != nil {
+	f := destinationCmd.Flags()
+	f.MarkDeprecated("syncPath", "moved to specific type, use destination.syncPath")
+	if err := viper.BindPFlags(f); err != nil {
 		log.Panic().
 			Err(err).
 			Str("command", "destination").

--- a/cmd/destination.go
+++ b/cmd/destination.go
@@ -38,6 +38,7 @@ import (
 )
 
 func init() {
+	viper.SetDefault("name", "destination") // name is required for mount checks and telemetry
 	viper.SetDefault("syncPath", "vsync/")
 	viper.SetDefault("numBuckets", 1) // we need atleast one bucket to store info
 	viper.SetDefault("destination.tick", "10s")
@@ -87,11 +88,6 @@ var destinationCmd = &cobra.Command{
 		originMounts := viper.GetStringSlice("origin.mounts")
 		destinationMounts := viper.GetStringSlice("destination.mounts")
 		hasher := sha256.New()
-
-		// name is required for mount checks and telemetry
-		if name != "" {
-			name = "destination"
-		}
 
 		// telemetry client
 		telemetryClient.AddTags("mpaas_application_name:vsync_" + name)

--- a/cmd/destination.go
+++ b/cmd/destination.go
@@ -39,11 +39,12 @@ import (
 
 func init() {
 	viper.SetDefault("name", "destination") // name is required for mount checks and telemetry
-	viper.SetDefault("syncPath", "vsync/")
-	viper.SetDefault("numBuckets", 1) // we need atleast one bucket to store info
+	viper.SetDefault("numBuckets", 1)       // we need atleast one bucket to store info
 	viper.SetDefault("destination.tick", "10s")
 	viper.SetDefault("destination.timeout", "5m")
+	viper.SetDefault("destination.syncPath", "vsync/")
 	viper.SetDefault("destination.numWorkers", 1) // we need atleast 1 worker or else the sync routine will be blocked
+	viper.SetDefault("origin.syncPath", "vsync/")
 	viper.SetDefault("origin.renewToken", true)
 
 	if err := viper.BindPFlags(destinationCmd.PersistentFlags()); err != nil {
@@ -82,14 +83,32 @@ var destinationCmd = &cobra.Command{
 
 		// initial configs
 		name := viper.GetString("name")
-		syncPath := viper.GetString("syncPath")
 		numBuckets := viper.GetInt("numBuckets")
 		tick := viper.GetDuration("destination.tick")
 		timeout := viper.GetDuration("destination.timeout")
 		numWorkers := viper.GetInt("destination.numWorkers")
+		originSyncPath := viper.GetString("origin.syncPath")
 		originMounts := viper.GetStringSlice("origin.mounts")
+		destinationSyncPath := viper.GetString("destination.syncPath")
 		destinationMounts := viper.GetStringSlice("destination.mounts")
 		hasher := sha256.New()
+
+		// deprecated
+		syncPathDepr := viper.GetString("syncPath")
+		if syncPathDepr != "" {
+			log.Error().Str("mode", "destination").Msg("syncPath variable is deprecated, use origin.syncPath and destination.syncPath, they can be same value")
+			return apperr.New(fmt.Sprintf("parameter %q deprecated, please use %q and %q; they can be same value", "syncPath", "destination.syncPath", "origin.syncPath"), ErrInitialize, op, apperr.Fatal)
+		}
+		originDcDepr := viper.GetString("origin.dc")
+		if originDcDepr != "" {
+			log.Error().Str("mode", "origin").Str("origin.dc", originDcDepr).Msg("origin.dc variable is deprecated, please use origin.consul.dc")
+			return apperr.New(fmt.Sprintf("parameter %q deprecated, use %q", "origin.dc", "origin.consul.dc"), ErrInitialize, op, apperr.Fatal)
+		}
+		destinationDcDepr := viper.GetString("destination.dc")
+		if destinationDcDepr != "" {
+			log.Error().Str("mode", "destination").Str("destination.dc", destinationDcDepr).Msg("destination.dc variable is deprecated, please use destination.consul.dc")
+			return apperr.New(fmt.Sprintf("parameter %q deprecated, use %q", "destination.dc", "destination.consul.dc"), ErrInitialize, op, apperr.Fatal)
+		}
 
 		// telemetry client
 		telemetryClient.AddTags("mpaas_application_name:vsync_" + name)
@@ -121,18 +140,22 @@ var destinationCmd = &cobra.Command{
 		}
 
 		// perform inital checks on sync path, check kv and token permissions
-		if syncPath[len(syncPath)-1:] != "/" {
-			syncPath = syncPath + "/"
+		if originSyncPath[len(originSyncPath)-1:] != "/" {
+			originSyncPath = originSyncPath + "/"
 		}
-		originSyncPath := syncPath + "origin/"
-		destinationSyncPath := syncPath + "destination/"
+		if destinationSyncPath[len(destinationSyncPath)-1:] != "/" {
+			destinationSyncPath = destinationSyncPath + "/"
+		}
+		// adds type into sync path, useful in case we use same syncPath in same consul
+		originSyncPath = originSyncPath + "origin/"
+		destinationSyncPath = destinationSyncPath + "destination/"
 
 		err = destinationConsul.SyncPathChecks(destinationSyncPath, consul.StdCheck)
 		if err != nil {
 			log.Debug().Err(err).Msg("failures on sync path checks on destination")
 			return apperr.New(fmt.Sprintf("sync path checks failed for %q", destinationSyncPath), err, op, apperr.Fatal, ErrInitialize)
 		}
-		log.Info().Str("path", syncPath).Msg("sync path passed initial checks on destination")
+		log.Info().Str("path", destinationSyncPath).Msg("sync path passed initial checks on destination")
 
 		err = originConsul.SyncPathChecks(originSyncPath, consul.StdCheck)
 		if err != nil {
@@ -206,9 +229,9 @@ var destinationCmd = &cobra.Command{
 		go prepareWatch(ctx, originConsul, originSyncPath, triggerCh, errCh)
 		go prepareTicker(ctx, originConsul, originSyncPath, tick, triggerCh, errCh)
 		go destinationSync(ctx, name,
-			originConsul, originVault, originMounts,
-			destinationConsul, destinationVault, destinationMounts,
-			syncPath, pack,
+			originConsul, originSyncPath, originVault, originMounts,
+			destinationConsul, destinationSyncPath, destinationVault, destinationMounts,
+			pack,
 			hasher, numBuckets, timeout, numWorkers,
 			triggerCh, errCh)
 
@@ -328,15 +351,13 @@ func prepareTicker(ctx context.Context, originConsul *consul.Client, originSyncP
 
 // destinationSync compares sync entries then update actual and sync entries
 func destinationSync(ctx context.Context, name string,
-	originConsul *consul.Client, originVault *vault.Client, originMounts []string,
-	destinationConsul *consul.Client, destinationVault *vault.Client, destinationMounts []string,
-	syncPath string, pack transformer.Pack,
+	originConsul *consul.Client, originSyncPath string, originVault *vault.Client, originMounts []string,
+	destinationConsul *consul.Client, destinationSyncPath string, destinationVault *vault.Client, destinationMounts []string,
+	pack transformer.Pack,
 	hasher hash.Hash, numBuckets int, timeout time.Duration, numWorkers int,
 	triggerCh chan bool, errCh chan error) {
 
 	const op = apperr.Op("cmd.destinationSync")
-	originSyncPath := syncPath + "origin/"
-	destinationSyncPath := syncPath + "destination/"
 
 	for {
 		select {

--- a/cmd/destination.go
+++ b/cmd/destination.go
@@ -55,9 +55,7 @@ func init() {
 			Msg("cannot bind flags with viper")
 	}
 
-	f := destinationCmd.Flags()
-	f.MarkDeprecated("syncPath", "moved to specific type, use destination.syncPath")
-	if err := viper.BindPFlags(f); err != nil {
+	if err := viper.BindPFlags(destinationCmd.Flags()); err != nil {
 		log.Panic().
 			Err(err).
 			Str("command", "destination").

--- a/cmd/origin.go
+++ b/cmd/origin.go
@@ -36,6 +36,7 @@ import (
 )
 
 func init() {
+	viper.SetDefault("name", "origin") // name is required for mount checks and telemetry
 	viper.SetDefault("syncPath", "vsync/")
 	viper.SetDefault("numBuckets", 1) // we need atleast one bucket to store info
 	viper.SetDefault("origin.tick", "10s")
@@ -83,11 +84,6 @@ var originCmd = &cobra.Command{
 		numWorkers := viper.GetInt("origin.numWorkers")
 		originMounts := viper.GetStringSlice("origin.mounts")
 		hasher := sha256.New()
-
-		// name is required for mount checks and telemetry
-		if name != "" {
-			name = "origin"
-		}
 
 		// telemetry client
 		telemetryClient.AddTags("mpaas_application_name:vsync_" + name)

--- a/cmd/origin.go
+++ b/cmd/origin.go
@@ -51,7 +51,9 @@ func init() {
 			Msg("cannot bind flags with viper")
 	}
 
-	if err := viper.BindPFlags(originCmd.Flags()); err != nil {
+	f := originCmd.Flags()
+	f.MarkDeprecated("syncPath", "moved to specific type, use origin.syncPath")
+	if err := viper.BindPFlags(f); err != nil {
 		log.Panic().
 			Err(err).
 			Str("command", "origin").

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,15 +66,15 @@ func init() {
 	rootCmd.PersistentFlags().String("log.level", "", "logger level (info|debug)")
 	rootCmd.PersistentFlags().String("log.type", "", "logger type (console|json)")
 
-	rootCmd.PersistentFlags().String("origin.dc", "", "origin datacenter")
+	rootCmd.PersistentFlags().String("origin.consul.dc", "", "origin consul datacenter")
 	rootCmd.PersistentFlags().String("origin.consul.address", "", "origin consul address")
 	rootCmd.PersistentFlags().String("origin.vault.address", "", "origin vault address")
 	rootCmd.PersistentFlags().String("origin.vault.token", "", "origin vault token")
 	rootCmd.PersistentFlags().String("origin.vault.role_id", "", "origin vault approle role_id")
 	rootCmd.PersistentFlags().String("origin.vault.secret_id", "", "origin vault approle secret_id")
 
-	rootCmd.PersistentFlags().String("destination.dc", "", "destination datacenter")
-	rootCmd.PersistentFlags().String("destination.consul.address", "", "destination vault address")
+	rootCmd.PersistentFlags().String("destination.consul.dc", "", "destination consul datacenter")
+	rootCmd.PersistentFlags().String("destination.consul.address", "", "destination consul address")
 	rootCmd.PersistentFlags().String("destination.vault.address", "", "destination vault address")
 	rootCmd.PersistentFlags().String("destination.vault.token", "", "destination vault token")
 	rootCmd.PersistentFlags().String("destination.vault.role_id", "", "destination vault approle role_id")

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -17,8 +17,8 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"time"
 	"strings"
+	"time"
 
 	"github.com/ExpediaGroup/vsync/apperr"
 	"github.com/ExpediaGroup/vsync/consul"
@@ -43,7 +43,7 @@ func getEssentials(mode string) (*consul.Client, *vault.Client, error) {
 		return nil, nil, apperr.New(fmt.Sprintf("cannot get %s consul address", mode), ErrInitialize, op, apperr.Fatal)
 	}
 
-	dc := viper.GetString(mode + "." + "dc")
+	dc := viper.GetString(mode + "." + "consul.dc")
 	if dc != "" {
 		log.Debug().Str("dc", dc).Str("mode", mode).Msg("datacenter from config")
 	} else {

--- a/configs/dest.v1.json
+++ b/configs/dest.v1.json
@@ -1,6 +1,5 @@
 {
     "name": "dest_v1",
-    "syncPath": "vsync/",
     "log": {
         "level": "debug",
         "type": "console"
@@ -10,7 +9,7 @@
         "dc": "dc1",
         "vault": {
             "address": "http://127.0.0.1:6200",
-            "token": "s.8Te1siHQnIoJ4k6el4pioQhz"
+            "token": "s.g1ew6c5qfpHASxWJsR2YJKXP"
         },
         "consul": {
             "address": "http://127.0.0.1:6500"
@@ -18,23 +17,25 @@
         "mounts": [
             "secret/"
         ],
+        "syncPath": "vsync/",
         "numWorkers": 5,
         "tick": "10s",
         "timeout": "10s",
         "renewToken": false
     },
     "destination": {
-        "dc": "dc2",
         "vault": {
             "address": "http://127.0.0.1:7200",
-            "token": "s.5LvYTJQhwyh2CvrZtUpnHeLb"
+            "token": "s.09Pyj90P186pQVp60zC1CCN7"
         },
         "consul": {
-            "address": "http://127.0.0.1:7500"
+            "dc": "dc1",
+            "address": "http://127.0.0.1:6500"
         },
         "mounts": [
             "secret/"
         ],
+        "syncPath": "vsync/",
         "numWorkers": 10,
         "tick": "10s",
         "timeout": "10s"

--- a/configs/dest.v2.json
+++ b/configs/dest.v2.json
@@ -1,40 +1,41 @@
 {
     "name": "dest_v2",
-    "syncPath": "vsync/",
     "log": {
         "level": "debug",
         "type": "console"
     },
     "numBuckets": 19,
     "origin": {
-        "dc": "dc1",
         "vault": {
             "address": "http://127.0.0.1:6200",
             "token": "s.M1R5N97REjYYYcMS1M45xAqY"
         },
         "consul": {
+            "dc": "dc1",
             "address": "http://127.0.0.1:6500"
         },
         "mounts": [
             "secret/"
         ],
+        "syncPath": "vsync/",
         "numWorkers": 5,
         "tick": "10s",
         "timeout": "10s",
         "renewToken": false
     },
     "destination": {
-        "dc": "dc2",
         "vault": {
             "address": "http://127.0.0.1:7200",
             "token": "s.Vux0ColMEJZpvvvfILZkoDpr"
         },
         "consul": {
+            "dc": "dc2",
             "address": "http://127.0.0.1:7500"
         },
         "mounts": [
             "secret/"
         ],
+        "syncPath": "vsync/",
         "numWorkers": 10,
         "tick": "10s",
         "timeout": "10s",

--- a/configs/dest.v3.json
+++ b/configs/dest.v3.json
@@ -1,13 +1,11 @@
 {
   "name": "dest_v3",
-  "syncPath": "vsync/",
   "log": {
     "level": "debug",
     "type": "console"
   },
   "numBuckets": 19,
   "origin": {
-    "dc": "dc1",
     "vault": {
       "address": "http://127.0.0.1:8200",
       "approle": {
@@ -17,24 +15,27 @@
       }
     },
     "consul": {
+      "dc": "dc1",
       "address": "http://127.0.0.1:8500"
     },
     "mounts": ["secret/"],
+    "syncPath": "vsync/",
     "numWorkers": 5,
     "tick": "10s",
     "timeout": "10s",
     "renewToken": true
   },
   "destination": {
-    "dc": "dc2",
     "vault": {
       "address": "http://127.0.0.1:7200",
       "token": "s.5LvYTJQhwyh2CvrZtUpnHeLb"
     },
     "consul": {
+      "dc": "dc2",
       "address": "http://127.0.0.1:7500"
     },
     "mounts": ["secret/"],
+    "syncPath": "vsync/",
     "numWorkers": 10,
     "tick": "10s",
     "timeout": "10s"

--- a/configs/dest_loop.v2.json
+++ b/configs/dest_loop.v2.json
@@ -1,40 +1,41 @@
 {
     "name": "dest_loop_v2",
-    "syncPath": "vsync/",
     "log": {
         "level": "debug",
         "type": "console"
     },
     "numBuckets": 19,
     "origin": {
-        "dc": "dc1",
         "vault": {
             "address": "http://127.0.0.1:6200",
             "token": "s.MDLmK6gOVLL33bB5TkdnJPOB"
         },
         "consul": {
+            "dc": "dc1",
             "address": "http://127.0.0.1:6500"
         },
         "mounts": [
             "secret/"
         ],
+        "syncPath": "vsync/",
         "numWorkers": 5,
         "tick": "10s",
         "timeout": "10s",
         "renewToken": false
     },
     "destination": {
-        "dc": "dc2",
         "vault": {
             "address": "http://127.0.0.1:6200",
             "token": "s.MDLmK6gOVLL33bB5TkdnJPOB"
         },
         "consul": {
+            "dc": "dc2",
             "address": "http://127.0.0.1:6500"
         },
         "mounts": [
             "secret/"
         ],
+        "syncPath": "vsync/",
         "numWorkers": 10,
         "tick": "10s",
         "timeout": "10s",

--- a/configs/origin.json
+++ b/configs/origin.json
@@ -1,23 +1,23 @@
 {
     "name": "origin",
-    "syncPath": "vsync/",
     "log": {
         "level": "debug",
         "type": "console"
     },
     "numBuckets": 19,
     "origin": {
-        "dc": "dc1",
         "vault": {
             "address": "http://127.0.0.1:6200",
-            "token": "s.M1R5N97REjYYYcMS1M45xAqY"
+            "token": "s.g1ew6c5qfpHASxWJsR2YJKXP"
         },
         "consul": {
+            "dc": "dc1",
             "address": "http://127.0.0.1:6500"
         },
         "mounts": [
             "secret/"
         ],
+        "syncPath": "vsync/",
         "numWorkers": 5,
         "tick": "10s",
         "timeout": "10s"

--- a/website/docs/getstarted/config.md
+++ b/website/docs/getstarted/config.md
@@ -21,6 +21,8 @@ sidebar_label: Config
 
 `syncPath` : consul kv path where vsync has to store its meta data (default: "vsync/")
 
+> Deprecated after v0.1.1, replaced by syncPath in origin and destination
+
 `dataPaths` : array of vault paths / mounts which needs to be synced
 
 > Deprecated after v0.0.1, replaced by mounts in origin and destination
@@ -36,6 +38,8 @@ sidebar_label: Config
 `origin` : top level key for all origin related config parameters
 
 `origin.dc` : origin consul datacenter. "--origin.dc" cli param
+
+> Deprecated after v0.1.1, replaced by dc in origin.consul.dc
 
 `origin.vault` : origin vault top level key
 
@@ -53,6 +57,8 @@ sidebar_label: Config
 
 `origin.consul.address` : origin consul address where we need to store vsync meta data ( sync info ). "--origin.consul.address" cli param
 
+`origin.consul.dc` : origin consul datacenter. "--origin.consul.dc" cli param
+
 `origin.numWorkers` : number of get insights worker (default: 1)
 
 `origin.tick` : interval for timer to start origin sync cycles. String format like 10m, 5s (default: "1m")
@@ -67,6 +73,8 @@ sidebar_label: Config
 
 `destination.dc` : destination consul datacenter
 
+> Deprecated after v0.1.1, replaced by dc in destination.consul.dc
+
 `destination.vault` : destination vault top level key
 
 `destination.vault.address` : destination vault address where we need to get metadata ( vault kv metadata ). "--destination.vault.address" cli param
@@ -80,6 +88,8 @@ sidebar_label: Config
 `destination.vault.approle.secret_id` : destination vault secret_id from an approle which has permissions to read, update, write in vault mounts. "--destination.vault.approle.secret_id" cli param (use token OR approle)
 
 `destination.mounts` : array of vault paths / mounts which needs to be synced. Each value needs to end with /. Token permissions to read, update, delete are checked for each cycle.
+
+`destination.consul.dc` : destination consul datacenter.  "--destination.consul.dc" cli param
 
 `destination.consul.address` : destination consul address where we need to store vsync meta data ( sync info ). "--destination.consul.address" cli param
 
@@ -103,7 +113,6 @@ Supported format: json, hcl, yaml through [viper](https://github.com/spf13/viper
 
 ```
 {
-    "syncPath": "vsync/",
     "log": {
         "level": "debug",
         "type": "console"
@@ -111,17 +120,18 @@ Supported format: json, hcl, yaml through [viper](https://github.com/spf13/viper
     "logLevel": "info",
     "numBuckets": 19,
     "origin": {
-        "dc": "dc1",
         "vault": {
             "address": "http://127.0.0.1:6200",
             "token": "s.MDLmK6gOVLL33bB5TkdnJPOB"
         },
         "consul": {
+            "dc": "dc1",
             "address": "http://127.0.0.1:6500"
         },
         "mounts": [
             "secret/"
         ],
+        "syncPath": "vsync/",
         "numWorkers": 5,
         "tick": "10s",
         "timeout": "10s"
@@ -133,37 +143,38 @@ Supported format: json, hcl, yaml through [viper](https://github.com/spf13/viper
 
 ```
 {
-    "syncPath": "vsync/",
     "log": {
         "level": "debug",
         "type": "console"
     },
     "numBuckets": 19,
     "origin": {
-        "dc": "dc1",
         "vault": {
             "address": "http://127.0.0.1:6200",
             "token": "s.8Te1siHQnIoJ4k6el4pioQhz"
         },
         "consul": {
+            "dc": "dc1",
             "address": "http://127.0.0.1:6500"
         },
         "mounts": [
             "secret/"
         ],
+        "syncPath": "vsync/",
         "numWorkers": 5,
         "tick": "10s",
         "timeout": "10s"
     },
     "destination": {
-        "dc": "dc2",
         "vault": {
             "address": "http://127.0.0.1:7200",
             "token": "s.5LvYTJQhwyh2CvrZtUpnHeLb"
         },
         "consul": {
+            "dc": "dc2",
             "address": "http://127.0.0.1:7500"
         },
+        "syncPath": "vsync/",
         "numWorkers": 10,
         "tick": "10s",
         "timeout": "10s"
@@ -175,37 +186,38 @@ Supported format: json, hcl, yaml through [viper](https://github.com/spf13/viper
 
 ```
 {
-    "syncPath": "vsync/",
     "log": {
         "level": "debug",
         "type": "console"
     },
     "numBuckets": 19,
     "origin": {
-        "dc": "dc1",
         "vault": {
             "address": "http://127.0.0.1:6200",
             "token": "s.8Te1siHQnIoJ4k6el4pioQhz"
         },
         "consul": {
+            "dc": "dc1",
             "address": "http://127.0.0.1:6500"
         },
         "mounts": [
             "runner/"
         ],
+        "syncPath": "vsync/",
         "numWorkers": 5,
         "tick": "10s",
         "timeout": "10s"
     },
     "destination": {
-        "dc": "dc2",
         "vault": {
             "address": "http://127.0.0.1:7200",
             "token": "s.5LvYTJQhwyh2CvrZtUpnHeLb"
         },
         "consul": {
+            "dc": "dc2",
             "address": "http://127.0.0.1:7500"
         },
+        "syncPath": "vsync/",
         "numWorkers": 10,
         "tick": "10s",
         "timeout": "10s",
@@ -226,37 +238,38 @@ We are transforming from one mount to another
 
 ```
 {
-    "syncPath": "vsync/",
     "log": {
         "level": "debug",
         "type": "console"
     },
     "numBuckets": 19,
     "origin": {
-        "dc": "dc1",
         "vault": {
             "address": "http://127.0.0.1:6200",
             "token": "s.MDLmK6gOVLL33bB5TkdnJPOB"
         },
         "consul": {
+            "dc": "dc1",
             "address": "http://127.0.0.1:6500"
         },
         "mounts": [
             "runner/"
         ],
+        "syncPath": "vsync/",
         "numWorkers": 5,
         "tick": "10s",
         "timeout": "10s"
     },
     "destination": {
-        "dc": "dc1",
         "vault": {
             "address": "http://127.0.0.1:6200",
             "token": "s.MDLmK6gOVLL33bB5TkdnJPOB"
         },
         "consul": {
+            "dc": "dc1",
             "address": "http://127.0.0.1:6500"
         },
+        "syncPath": "vsync/",
         "numWorkers": 10,
         "tick": "10s",
         "timeout": "10s",

--- a/website/docs/getstarted/install.md
+++ b/website/docs/getstarted/install.md
@@ -33,15 +33,15 @@ Available Commands:
 
 Flags:
   -c, --config string                       load the config file along with path (default is $HOME/.vsync.json)
-      --destination.consul.address string   destination vault address
-      --destination.dc string               destination datacenter
+      --destination.consul.address string   destination consul address
+      --destination.consul.dc string               destination consul datacenter
       --destination.vault.address string    destination vault address
       --destination.vault.token string      destination vault token
   -h, --help                                help for vsync
       --log.level string                    logger level (info|debug)
       --log.type string                     logger type (console|json)
       --origin.consul.address string        origin consul address
-      --origin.dc string                    origin datacenter
+      --origin.consul.dc string             origin consul datacenter
       --origin.vault.address string         origin vault address
       --origin.vault.token string           origin vault token
       --version                             version information

--- a/website/docs/getstarted/install.md
+++ b/website/docs/getstarted/install.md
@@ -34,7 +34,7 @@ Available Commands:
 Flags:
   -c, --config string                       load the config file along with path (default is $HOME/.vsync.json)
       --destination.consul.address string   destination consul address
-      --destination.consul.dc string               destination consul datacenter
+      --destination.consul.dc string        destination consul datacenter
       --destination.vault.address string    destination vault address
       --destination.vault.token string      destination vault token
   -h, --help                                help for vsync


### PR DESCRIPTION
Sync Path was only one per config so its should be same for origin and destination.
At times when you need to store multiple vsync destinations data under same consul then we would need to store the sync path for origin and destination differently, each destination has its own sync path. 

Variable syncPath deprecated, use origin.syncPath and destination.syncPath
Variable origin.dc deprecated, use origin.consul.dc
Variable destination.dc deprecated, use destination.consul.dc