### PR TITLE
Fix checks permissions, fix #27

### DIFF
--- a/vault/check.go
+++ b/vault/check.go
@@ -107,7 +107,8 @@ func (v *Client) CheckTokenPermissions(p string, checks int, name string) error 
 	parentPath := metaPath[:strings.LastIndex(metaPath, "/")]
 
 	// create
-	if checks&(WriteCheck) != 0 {
+	check := WriteCheck
+	if checks&check == check {
 		_, err = v.Logical().Write(path, data)
 		if err != nil {
 			log.Debug().Err(err).Str("path", path).Msg("cannot create data in path")
@@ -117,7 +118,8 @@ func (v *Client) CheckTokenPermissions(p string, checks int, name string) error 
 	}
 
 	// list
-	if checks&(WriteCheck|ListCheck) != 0 {
+	check = WriteCheck | ListCheck
+	if checks&check == check {
 		paths, _, err := v.DeepListPaths(parentPath)
 		if err != nil {
 			log.Debug().Err(err).Str("path", path).Msg("cannot list paths in path")
@@ -139,7 +141,8 @@ func (v *Client) CheckTokenPermissions(p string, checks int, name string) error 
 	}
 
 	// read
-	if checks&(WriteCheck|ListCheck|ReadCheck) != 0 {
+	check = WriteCheck | ListCheck | ReadCheck
+	if checks&check == check {
 		secret, err := v.Logical().Read(path)
 		if err != nil {
 			log.Debug().Err(err).Str("path", path).Msg("cannot read data from path")
@@ -162,7 +165,8 @@ func (v *Client) CheckTokenPermissions(p string, checks int, name string) error 
 	}
 
 	// delete
-	if checks&(WriteCheck|ListCheck|ReadCheck|DeleteCheck) != 0 {
+	check = WriteCheck | ListCheck | ReadCheck | DeleteCheck
+	if checks&check == check {
 		_, err = v.Logical().Delete(path)
 		if err != nil {
 			log.Debug().Err(err).Str("path", path).Msg("cannot delete data from path")


### PR DESCRIPTION
This will do only the necessary checks, this allow to got an "hardened" policy with only giving write permissions in the vsyncChecks path.

This fix all my sync issues with #29 

With this policy for the origin (we can maybe remove more perms)

```
$ vault policy read vsync-ro
path "auth/token/lookup-self" {
  capabilities = ["read"]
}
path "kv/*" {
    capabilities = ["list", "read"]
}
path "kv/data/*" {
  capabilities = ["list", "read"]
}
path "kv/metadata/*" {
  capabilities = ["list", "read"]
}
path "kv/metadata/vsyncChecks" {
  capabilities = ["create", "read", "update", "delete", "list"]
}
path "kv/data/vsyncChecks" {
  capabilities = ["create", "read", "update", "list"]
}
path "kv/metadata/vsyncChecks/*" {
  capabilities = ["create", "read", "update", "delete", "list"]
}
path "kv/data/vsyncChecks/*" {
  capabilities = ["create", "read", "update", "delete", "list"]
}
path "sys/mounts" {
  capabilities = ["list", "read"]
}
path "sys/mounts/*" {
  capabilities = ["list", "read"]
}
path "sys/policies/*" {
    capabilities = ["list", "read"]
}
path "sys/policy/*" {
    capabilities = ["list", "read"]
}
path "sys/policy" {
    capabilities = ["list", "read"]
}
path "auth/approle/*" {
    capabilities = ["list"]
}
path "auth/approle/vsync-ro" {
    capabilities = ["read"]
}
````

Does it make sense for you?

kudos to @maximbaz who help me on this.